### PR TITLE
upgrade from deprecated importlib.resources function

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = msise00
-version = 1.10.1
+version = 1.11.0
 description = Python API for Fortran MSISE-00 neutral atmosphere model.
 author = Michael Hirsch, Ph.D.
 author_email = scivision@users.noreply.github.com
@@ -22,7 +22,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 
 [options]
-python_requires = >= 3.7
+python_requires = >= 3.9
 packages = find:
 include_package_data = True
 zip_safe = False

--- a/src/msise00/base.py
+++ b/src/msise00/base.py
@@ -7,20 +7,20 @@ http://nssdcftp.gsfc.nasa.gov/models/atmospheric/msis/nrlmsise00/
 """
 
 from __future__ import annotations
-import typing as T
-import os
-import logging
-import importlib.resources
-from datetime import datetime, date
-import xarray
-import numpy as np
-import subprocess
-import shutil
 
-from .timeutils import todatetime
+import importlib.resources
+import logging
+import os
+import shutil
+import subprocess
+import typing as T
+from datetime import date, datetime
 
 import geomagindices as gi
+import numpy as np
+import xarray
 
+from .timeutils import todatetime
 
 species = ["He", "O", "N2", "O2", "Ar", "Total", "H", "N", "AnomalousO"]
 ttypes = ["Texo", "Tn"]
@@ -35,7 +35,7 @@ def build():
     if not cmake:
         raise FileNotFoundError("CMake not available")
 
-    with importlib.resources.path(__package__, "CMakeLists.txt") as f:
+    with importlib.resources.as_file(importlib.resources.files(__package__)/'CMakeLists.txt') as f:
         s = f.parent
         b = s / "build"
         g = []
@@ -161,38 +161,35 @@ def rungtd1d(
     if not np.isfinite(Ap):
         raise ValueError("Ap is not finite.")
 
-    try:
-        with importlib.resources.path(__package__, exe_name) as exe:
-            pass
-    except FileNotFoundError:
+    exe = importlib.resources.files(__package__)/exe_name
+    if not os.path.exists(exe):
         build()
 
-    with importlib.resources.path(__package__, exe_name) as exe:
-        for i, a in enumerate(altkm):
-            cmd = [
-                str(exe),
-                doy,
-                str(time.hour),
-                str(time.minute),
-                str(time.second),
-                str(glat),
-                str(glon),
-                str(f107s),
-                str(f107),
-                str(Ap),
-                str(a),
-            ]
+    for i, a in enumerate(altkm):
+        cmd = [
+            str(exe),
+            doy,
+            str(time.hour),
+            str(time.minute),
+            str(time.second),
+            str(glat),
+            str(glon),
+            str(f107s),
+            str(f107),
+            str(Ap),
+            str(a),
+        ]
 
-            logging.info(" ".join(cmd))
+        logging.info(" ".join(cmd))
 
-            ret = subprocess.check_output(cmd, text=True)
+        ret = subprocess.check_output(cmd, text=True)
 
-            # different compilers throw in extra \n
-            raw = list(map(float, ret.split()))
-            if not len(raw) == 9 + 2:
-                raise ValueError(ret)
-            dens[i, :] = raw[:9]
-            temp[i, :] = raw[9:]
+        # different compilers throw in extra \n
+        raw = list(map(float, ret.split()))
+        if not len(raw) == 9 + 2:
+            raise ValueError(ret)
+        dens[i, :] = raw[:9]
+        temp[i, :] = raw[9:]
 
     dsf = {
         k: (("time", "alt_km", "lat", "lon"), v[None, :, None, None])

--- a/src/msise00/tests/test_ccmc.py
+++ b/src/msise00/tests/test_ccmc.py
@@ -16,7 +16,7 @@ def test_ccmc():
     altkm = 400.0
     indices = {"f107s": 163.6666, "f107": 146.7, "Ap": 7}
 
-    with importlib.resources.path(__package__, "ccmc.log") as fn:
+    with importlib.resources.as_file(importlib.resources.files(__package__)/"ccmc.log") as fn:
         A = np.loadtxt(fn, skiprows=25)
 
     atmos = msise00.run(t, altkm, glat, glon, indices)

--- a/src/msise00/tests/test_grid.py
+++ b/src/msise00/tests/test_grid.py
@@ -20,7 +20,7 @@ time = "2017-03-01T12"
 def test_one_alt_one_time():
     pytest.importorskip("netCDF4")
 
-    with importlib.resources.path(__package__, "ref3.nc") as fn:
+    with importlib.resources.as_file(importlib.resources.files(__package__)/"ref3.nc") as fn:
         ref = xarray.open_dataset(fn)
 
     lat, lon = msise00.worldgrid.latlonworldgrid(30, 60)
@@ -35,7 +35,7 @@ def test_one_alt_one_time():
 def test_script(tmp_path):
     pytest.importorskip("netCDF4")
 
-    with importlib.resources.path(__package__, "ref3.nc") as fn:
+    with importlib.resources.as_file(importlib.resources.files(__package__)/"ref3.nc") as fn:
         ref = xarray.open_dataset(fn)
 
     fn = tmp_path / "test.nc"

--- a/src/msise00/tests/test_point.py
+++ b/src/msise00/tests/test_point.py
@@ -22,7 +22,7 @@ time = "2017-03-01T12"
 def test_one_loc_one_time(altkm, reffn):
     pytest.importorskip("netCDF4")
 
-    with importlib.resources.path(__package__, reffn) as fn:
+    with importlib.resources.as_file(importlib.resources.files(__package__)/reffn) as fn:
         ref = xarray.open_dataset(fn)
 
     try:
@@ -36,7 +36,7 @@ def test_one_loc_one_time(altkm, reffn):
 def test_script(altkm, reffn, tmp_path):
     pytest.importorskip("netCDF4")
 
-    with importlib.resources.path(__package__, reffn) as fn:
+    with importlib.resources.as_file(importlib.resources.files(__package__)/reffn) as fn:
         ref = xarray.open_dataset(fn)
 
     fn = tmp_path / "test.nc"

--- a/src/msise00/tests/test_time_grid.py
+++ b/src/msise00/tests/test_time_grid.py
@@ -19,7 +19,7 @@ altkm = 200.0
 def test_multiple_time():
     pytest.importorskip("netCDF4")
 
-    with importlib.resources.path(__package__, "ref4.nc") as fn:
+    with importlib.resources.as_file(importlib.resources.files(__package__, "ref4.nc")) as fn:
         ref = xarray.open_dataset(fn)
 
     lat, lon = msise00.worldgrid.latlonworldgrid(90, 90)
@@ -34,7 +34,7 @@ def test_multiple_time():
 def test_script(tmp_path):
     pytest.importorskip("netCDF4")
 
-    with importlib.resources.path(__package__, "ref4.nc") as fn:
+    with importlib.resources.as_file(importlib.resources.files(__package__, "ref4.nc")) as fn:
         ref = xarray.open_dataset(fn)
 
     fn = tmp_path / "test.nc"


### PR DESCRIPTION
Fixes https://github.com/space-physics/msise00/issues/24 by removing the deprecated calls to `importlib.resources.path` and by fixing a check for whether the build has occurred.